### PR TITLE
OICI:211 filtre prescripteur

### DIFF
--- a/openimis.json
+++ b/openimis.json
@@ -48,7 +48,7 @@
     },
         {
         "name": "LocationModule",
-        "npm": "@openimis/fe-location@git+https://github.com/ArkeupIDComores/openimis-fe-location_js.git#feature-filtre-prescripteur"
+        "npm": "@openimis/fe-location@git+https://github.com/ArkeupIDComores/openimis-fe-location_js.git#test-comores"
     },
     {
       "name": "InsureeModule",

--- a/openimis.json
+++ b/openimis.json
@@ -48,7 +48,7 @@
     },
         {
         "name": "LocationModule",
-        "npm": "@openimis/fe-location@git+https://github.com/ArkeupIDComores/openimis-fe-location_js.git#develop-arkeup"
+        "npm": "@openimis/fe-location@git+https://github.com/ArkeupIDComores/openimis-fe-location_js.git#feature-filtre-prescripteur"
     },
     {
       "name": "InsureeModule",


### PR DESCRIPTION
Changed the LocationModule npm source to point to the 'feature-filtre-prescripteur' branch instead of 'develop-arkeup' for the openimis-fe-location_js repository.