### PR TITLE
OICI 213:lot9 -Update MedicalModule npm branch reference

### DIFF
--- a/openimis.json
+++ b/openimis.json
@@ -56,7 +56,7 @@
     },
         {
         "name": "MedicalModule",
-        "npm": "@openimis/fe-medical@git+https://github.com/ArkeupIDComores/openimis-fe-medical_js.git#develop-arkeup"
+        "npm": "@openimis/fe-medical@git+https://github.com/ArkeupIDComores/openimis-fe-medical_js.git#test-comores"
     },
         {
         "name": "MedicalPriceListModule",


### PR DESCRIPTION
Changed the MedicalModule npm source branch from 'develop-arkeup' to 'test-comores' in openimis.json to use the latest test branch for development or testing purposes.